### PR TITLE
Fix border style and add dashboard page

### DIFF
--- a/src/app/components/Plan/plan.tsx
+++ b/src/app/components/Plan/plan.tsx
@@ -28,10 +28,10 @@ const PricingCard = ({
       initial={{ opacity: 0, y: 20 }}
       animate={inView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.5, delay }}
-      className={`relative p-8 rounded-xl bg-white dark:bg-gray-800 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 border ${
-        highlight 
-          ? 'border-2 border-yellow-400 dark:border-yellow-500' 
-          : 'border-gray-200 dark:border-gray-700'
+      className={`relative p-8 rounded-xl bg-white dark:bg-gray-800 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 ${
+        highlight
+          ? 'border-2 border-yellow-400 dark:border-yellow-500'
+          : 'border border-gray-200 dark:border-gray-700'
       }`}
     >
       {highlight && (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Dashboard() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- fix the border styling in the pricing cards
- add a simple dashboard page so login redirect works

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@supabase/auth-helpers-nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_685181bcd96083218970342033eb1edf