### PR TITLE
Add simple dashboard and chat table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Dashboard
+
+A basic dashboard is available at `/dashboard` once logged in. It loads your profile and shows a simple feed of other users. Matching and chat features will be expanded in the future.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+
+interface Profile {
+  id: string
+  full_name: string
+  city: string
+}
+
+export default function Dashboard() {
+  const router = useRouter()
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [feed, setFeed] = useState<Profile[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        router.push('/auth/login')
+        return
+      }
+
+      const { data: profileData } = await supabase
+        .from('profiles')
+        .select('id, full_name, city')
+        .eq('id', user.id)
+        .single()
+
+      if (profileData) setProfile(profileData as Profile)
+
+      const { data: feedData } = await supabase
+        .from('profiles')
+        .select('id, full_name, city')
+        .neq('id', user.id)
+        .limit(10)
+
+      if (feedData) setFeed(feedData as Profile[])
+    }
+
+    load()
+  }, [router])
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      {profile && (
+        <div className="mb-6">
+          <h2 className="text-xl">Welcome, {profile.full_name}</h2>
+        </div>
+      )}
+      <div className="grid md:grid-cols-2 gap-8">
+        <div>
+          <h3 className="text-lg font-semibold mb-2">Feed</h3>
+          <ul className="space-y-2">
+            {feed.map((user) => (
+              <li key={user.id} className="p-3 border rounded">
+                {user.full_name} {user.city ? `- ${user.city}` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold mb-2">Matches</h3>
+          <p className="text-gray-600">Matching feature coming soon.</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Slider from './components/Slider/slider'
 import PremiumFeatures from './components/Premium/premium'
 import { Footer, PricingSection } from './components/Plan/plan'
 
-const page = () => {
+const Page = () => {
   return (
     <main>
       <Main></Main>
@@ -20,4 +20,5 @@ const page = () => {
     
   )
 }
-export default page
+
+export default Page

--- a/supabase/sql/messages.sql
+++ b/supabase/sql/messages.sql
@@ -1,0 +1,20 @@
+-- Basic chat messages table
+create table messages (
+  id uuid default uuid_generate_v4() primary key,
+  sender_id uuid references profiles(id) on delete cascade not null,
+  recipient_id uuid references profiles(id) on delete cascade not null,
+  content text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Index for faster lookups
+create index idx_messages_sender_recipient on messages(sender_id, recipient_id);
+
+-- Enable RLS
+alter table messages enable row level security;
+
+-- Allow users to insert and select their own messages
+create policy "Users can interact with messages" on messages
+  for all
+  using (auth.uid() = sender_id or auth.uid() = recipient_id)
+  with check (auth.uid() = sender_id);


### PR DESCRIPTION
## Summary
- fix homepage default export
- add a dashboard page using Supabase for session and simple feed
- include a Supabase SQL file for messages
- document dashboard in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518239fb608321b9e163e17772e10b